### PR TITLE
Add operating system version to ad computer reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactored `ADAuditTasksComputer` class to improve clarity and maintainability, moving data transformation logic to `Build-ADAuditTasksComputer` function.
 - Adjusted `Build-ADAuditTasksComputer` function to align with the refactored `ADAuditTasksComputer` class, preserving original functionality and output format.
+- Refactored Initialize-ModuleEnv function to use force parameter and set to medium. Setting to high in future update.
 
 
 ## [0.8.1] - 2023-11-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2023-11-16
+
 ### Fixed
 
 - Fixed 'Get-ADHostAudit' to properly create filename for log when device type is missing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `OperatingSystemVersion` and `OperatingSystemBuildName` properties to `ADAuditTasksComputer` class.
+- Updated `Build-ADAuditTasksComputer` function to include logic for mapping OS versions to human-readable names using new hash tables `$osVersionMapWorkstation` and `$osVersionMapServer`.
+- Modified `Get-ADHostAudit` function to include `OperatingSystemVersion` in `$propsArray`, ensuring compatibility with changes in `ADAuditTasksComputer` class.
+
+### Changed
+
+- Refactored `ADAuditTasksComputer` class to improve clarity and maintainability, moving data transformation logic to `Build-ADAuditTasksComputer` function.
+- Adjusted `Build-ADAuditTasksComputer` function to align with the refactored `ADAuditTasksComputer` class, preserving original functionality and output format.
+
+
 ## [0.8.1] - 2023-11-16
 
 ### Fixed

--- a/ModdedModules/Helpers/buildpak.ps1
+++ b/ModdedModules/Helpers/buildpak.ps1
@@ -68,10 +68,10 @@ Get-NetworkAudit -Ports 443 -Computers $test1 -Report -NoHops -AddService
 #>
 
 <#
-    $ver = "v0.8.0"
+    $ver = "v0.8.1"
     git checkout main
     git pull origin main
-    git tag -a $ver -m "Release version $ver Minor Update"
+    git tag -a $ver -m "Release version $ver Bugfix Update"
     git push origin $ver
     "Fix: PR #37"
     git push origin $ver

--- a/build.yaml
+++ b/build.yaml
@@ -80,7 +80,7 @@ BuildWorkflow:
     #- Merge_CodeCoverage_Files
 
   publish:
-    - publish_module_to_gallery
+  #  - publish_module_to_gallery
 
     - Publish_Release_To_GitHub
 

--- a/source/Classes/2.ADAuditTasksComputer.ps1
+++ b/source/Classes/2.ADAuditTasksComputer.ps1
@@ -5,7 +5,7 @@ class ADAuditTasksComputer {
     [string]$IPv4Address
     [string]$IPv6Address
     [string]$OperatingSystem
-    [string]$LastLogon
+    [DateTime]$LastLogon
     [string]$LastSeen
     [string]$Created
     [string]$Modified
@@ -14,11 +14,15 @@ class ADAuditTasksComputer {
     [string]$OrgUnit
     [string]$KerberosEncryptionType
     [string]$SPNs
+    [string]$OperatingSystemVersion
+    [string]$OperatingSystemBuildName
+
     # Default constructor
     ADAuditTasksComputer() {
         $this.ComputerName = 'DefaultComputer'
     }
-    # Constructor 1
+
+    # Parameterized Constructor
     ADAuditTasksComputer(
         [string]$DNSHostName,
         [string]$ComputerName,
@@ -26,50 +30,39 @@ class ADAuditTasksComputer {
         [string]$IPv4Address,
         [string]$IPv6Address,
         [string]$OperatingSystem,
-        [long]$LastLogon,
-        [long]$LastSeen,
+        [DateTime]$LastLogon,
+        [string]$LastSeen,
         [string]$Created,
         [string]$Modified,
         [string]$Description,
         [string]$OrgUnit,
         [string]$KerberosEncryptionType,
         [string]$SPNs,
-        [string]$GroupMemberships
+        [string]$GroupMemberships,
+        [string]$OperatingSystemVersion,
+        [string]$OperatingSystemBuildName
     ) {
-        #Begin Contructor 1
         $this.DNSHostName = $DNSHostName
         $this.ComputerName = $ComputerName
         $this.Enabled = $Enabled
         $this.IPv4Address = $IPv4Address
         $this.IPv6Address = $IPv6Address
         $this.OperatingSystem = $OperatingSystem
-        $this.LastLogon = ([DateTime]::FromFileTime($LastLogon))
-        $this.LastSeen = $(
-            switch (([DateTime]::FromFileTime($LastSeen))) {
-                # Over 90 Days
-                { ($_ -lt (Get-Date).Adddays( - (90))) } { '3+ months'; break }
-                # Over 60 Days
-                { ($_ -lt (Get-Date).Adddays( - (60))) } { '2+ months'; break }
-                # Over 30 Days
-                { ($_ -lt (Get-Date).Adddays( - (30))) } { '1+ month'; break }
-                default { 'Recently' }
-            } # End Switch
-        ) # End LastSeen
+        $this.LastLogon = $LastLogon
+        $this.LastSeen = $LastSeen
         $this.Created = $Created
         $this.Modified = $Modified
         $this.Description = $Description
-        $this.GroupMemberships = $(
-            switch ($GroupMemberships) {
-                { if ($_) { return $true } } { $(Get-ADGroupMemberof -SamAccountName $GroupMemberships -AccountType ADComputer); break }
-                default { 'GroupsNotFound' }
-            }
-        )
-        $this.OrgUnit = $(($OrgUnit -replace '^.*?,(?=[A-Z]{2}=)') -replace ",", ">")
-        $this.KerberosEncryptionType = $(($KerberosEncryptionType | Select-Object -ExpandProperty $_) -replace ", ", " | ")
+        $this.GroupMemberships = $GroupMemberships
+        $this.OrgUnit = $OrgUnit
+        $this.KerberosEncryptionType = $KerberosEncryptionType
         $this.SPNs = $SPNs
-    }# End Constuctor 1
+        $this.OperatingSystemVersion = $OperatingSystemVersion
+        $this.OperatingSystemBuildName = $OperatingSystemBuildName
+    }
+
     # ToString() method override
     [string] ToString() {
-        return "ADAuditTasksComputer: $($this.ComputerName), DNS Host Name: $($this.DNSHostName), Enabled: $($this.Enabled), IPv4 Address: $($this.IPv4Address), IPv6 Address: $($this.IPv6Address), Operating System: $($this.OperatingSystem), Last Logon: $($this.LastLogon), Last Seen: $($this.LastSeen), Created: $($this.Created), Modified: $($this.Modified), Description: $($this.Description), Group Memberships: $($this.GroupMemberships), Org Unit: $($this.OrgUnit), Kerberos Encryption Type: $($this.KerberosEncryptionType), SPNs: $($this.SPNs)"
+        return "ADAuditTasksComputer: $($this.ComputerName), DNS Host Name: $($this.DNSHostName), Enabled: $($this.Enabled), IPv4 Address: $($this.IPv4Address), IPv6 Address: $($this.IPv6Address), Operating System: $($this.OperatingSystem), Last Logon: $($this.LastLogon), Last Seen: $($this.LastSeen), Created: $($this.Created), Modified: $($this.Modified), Description: $($this.Description), Group Memberships: $($this.GroupMemberships), Org Unit: $($this.OrgUnit), Kerberos Encryption Type: $($this.KerberosEncryptionType), SPNs: $($this.SPNs), Operating System Version: $($this.OperatingSystemVersion), Operating System Build Name: $($this.OperatingSystemBuildName)"
     }
 }

--- a/source/Private/Build-ADAuditTasksComputer.ps1
+++ b/source/Private/Build-ADAuditTasksComputer.ps1
@@ -21,6 +21,8 @@ function Build-ADAuditTasksComputer {
 
     # Hash tables for Operating System version mapping
     $osVersionMapWorkstation = @{
+        "5.1 (2600)"   = "Windows XP"
+        "6.0 (6000)"   = "Windows Vista"
         "6.1 (7600)"   = "Windows 7"
         "6.1 (7601)"   = "Windows 7 SP1"
         "6.2 (9200)"   = "Windows 8"
@@ -41,6 +43,7 @@ function Build-ADAuditTasksComputer {
         "10.0 (22000)" = "Windows 11 21H2"
     }
     $osVersionMapServer = @{
+        "5.2 (3790)"   = "Windows Server 2003"
         "6.0 (6000)"   = "Windows Server 2008"
         "6.0 (6001)"   = "Windows Server 2008 SP1"
         "6.0 (6002)"   = "Windows Server 2008 SP2"
@@ -62,7 +65,6 @@ function Build-ADAuditTasksComputer {
     Write-AuditLog "Begin ADAuditTasksComputer object creation."
 
     $Export = $ADComputers | ForEach-Object {
-        # Inside Build-ADAuditTasksComputer function
 
         $osVersion = $_.OperatingSystemVersion -replace '^\s+|\s+$', '' # Trim whitespace
         if (-not $osVersion) { $osVersion = "Unknown" } # Handle null/empty values

--- a/source/Private/Build-ADAuditTasksComputer.ps1
+++ b/source/Private/Build-ADAuditTasksComputer.ps1
@@ -21,10 +21,10 @@ function Build-ADAuditTasksComputer {
 
     # Hash tables for Operating System version mapping
     $osVersionMapWorkstation = @{
-        "6.1 (7600)" = "Windows 7"
-        "6.1 (7601)" = "Windows 7 SP1"
-        "6.2 (9200)" = "Windows 8"
-        "6.3 (9600)" = "Windows 8.1"
+        "6.1 (7600)"   = "Windows 7"
+        "6.1 (7601)"   = "Windows 7 SP1"
+        "6.2 (9200)"   = "Windows 8"
+        "6.3 (9600)"   = "Windows 8.1"
         "10.0 (10240)" = "Windows 10 1507"
         "10.0 (10586)" = "Windows 10 1511"
         "10.0 (14393)" = "Windows 10 1607"
@@ -41,13 +41,13 @@ function Build-ADAuditTasksComputer {
         "10.0 (22000)" = "Windows 11 21H2"
     }
     $osVersionMapServer = @{
-        "6.0 (6000)" = "Windows Server 2008"
-        "6.0 (6001)" = "Windows Server 2008 SP1"
-        "6.0 (6002)" = "Windows Server 2008 SP2"
-        "6.1 (7600)" = "Windows Server 2008 R2"
-        "6.1 (7601)" = "Windows Server 2008 R2 SP1"
-        "6.2 (9200)" = "Windows Server 2012"
-        "6.3 (9600)" = "Windows Server 2012 R2"
+        "6.0 (6000)"   = "Windows Server 2008"
+        "6.0 (6001)"   = "Windows Server 2008 SP1"
+        "6.0 (6002)"   = "Windows Server 2008 SP2"
+        "6.1 (7600)"   = "Windows Server 2008 R2"
+        "6.1 (7601)"   = "Windows Server 2008 R2 SP1"
+        "6.2 (9200)"   = "Windows Server 2012"
+        "6.3 (9600)"   = "Windows Server 2012 R2"
         "10.0 (14393)" = "Windows Server 2016"
         "10.0 (17763)" = "Windows Server 2019"
         "10.0 (20348)" = "Windows Server 2022"
@@ -62,13 +62,31 @@ function Build-ADAuditTasksComputer {
     Write-AuditLog "Begin ADAuditTasksComputer object creation."
 
     $Export = $ADComputers | ForEach-Object {
-        # Determine the Operating System Version and Build Name
-        $osVersion = $_.OperatingSystemVersion
+        # Inside Build-ADAuditTasksComputer function
+
+        $osVersion = $_.OperatingSystemVersion -replace '^\s+|\s+$', '' # Trim whitespace
+        if (-not $osVersion) { $osVersion = "Unknown" } # Handle null/empty values
+
         $osBuildName = if ($_.OperatingSystem -like "*Server*") {
-            $osVersionMapServer[$osVersion]
-        } else {
-            $osVersionMapWorkstation[$osVersion]
+            if ($null -ne $osVersionMapServer[$osVersion]) {
+                $osVersionMapServer[$osVersion]
+            }
+            else {
+                "Unknown Server OS"
+            }
         }
+        elseif ($_.OperatingSystem -notlike "*windows*") {
+            "Non-Windows OS" # Default for non-Windows
+        }
+        else {
+            if ($null -ne $osVersionMapWorkstation[$osVersion]) {
+                $osVersionMapWorkstation[$osVersion]
+            }
+            else {
+                "Unknown Workstation OS"
+            }
+        }
+
 
         # Convert LastLogonTimestamp and LastSeen to DateTime
         $lastLogonDateTime = [DateTime]::FromFileTime($_.lastLogonTimestamp)

--- a/source/Private/Build-ADAuditTasksComputer.ps1
+++ b/source/Private/Build-ADAuditTasksComputer.ps1
@@ -40,7 +40,10 @@ function Build-ADAuditTasksComputer {
         "10.0 (19042)" = "Windows 10 20H2"
         "10.0 (19043)" = "Windows 10 21H1"
         "10.0 (19044)" = "Windows 10 21H2"
+        "10.0 (19045)" = "Windows 10 22H2"
         "10.0 (22000)" = "Windows 11 21H2"
+        "10.0 (22621)" = "Windows 11 22H2"
+        "10.0 (22631)" = "Windows 11 23H2"
     }
     $osVersionMapServer = @{
         "5.2 (3790)"   = "Windows Server 2003"

--- a/source/Private/Build-ADAuditTasksComputer.ps1
+++ b/source/Private/Build-ADAuditTasksComputer.ps1
@@ -18,15 +18,74 @@ function Build-ADAuditTasksComputer {
     param (
         [pscustomobject[]]$ADComputers
     )
+
+    # Hash tables for Operating System version mapping
+    $osVersionMapWorkstation = @{
+        "6.1 (7600)" = "Windows 7"
+        "6.1 (7601)" = "Windows 7 SP1"
+        "6.2 (9200)" = "Windows 8"
+        "6.3 (9600)" = "Windows 8.1"
+        "10.0 (10240)" = "Windows 10 1507"
+        "10.0 (10586)" = "Windows 10 1511"
+        "10.0 (14393)" = "Windows 10 1607"
+        "10.0 (15063)" = "Windows 10 1703"
+        "10.0 (16299)" = "Windows 10 1709"
+        "10.0 (17134)" = "Windows 10 1803"
+        "10.0 (17763)" = "Windows 10 1809"
+        "10.0 (18362)" = "Windows 10 1903"
+        "10.0 (18363)" = "Windows 10 1909"
+        "10.0 (19041)" = "Windows 10 2004"
+        "10.0 (19042)" = "Windows 10 20H2"
+        "10.0 (19043)" = "Windows 10 21H1"
+        "10.0 (19044)" = "Windows 10 21H2"
+        "10.0 (22000)" = "Windows 11 21H2"
+    }
+    $osVersionMapServer = @{
+        "6.0 (6000)" = "Windows Server 2008"
+        "6.0 (6001)" = "Windows Server 2008 SP1"
+        "6.0 (6002)" = "Windows Server 2008 SP2"
+        "6.1 (7600)" = "Windows Server 2008 R2"
+        "6.1 (7601)" = "Windows Server 2008 R2 SP1"
+        "6.2 (9200)" = "Windows Server 2012"
+        "6.3 (9600)" = "Windows Server 2012 R2"
+        "10.0 (14393)" = "Windows Server 2016"
+        "10.0 (17763)" = "Windows Server 2019"
+        "10.0 (20348)" = "Windows Server 2022"
+    }
+
     if (!($script:LogString)) {
         Write-AuditLog -Start
     }
     else {
         Write-AuditLog -BeginFunction
     }
-    Write-AuditLog "Begin ADAUditTasksComputer object creation."
+    Write-AuditLog "Begin ADAuditTasksComputer object creation."
 
     $Export = $ADComputers | ForEach-Object {
+        # Determine the Operating System Version and Build Name
+        $osVersion = $_.OperatingSystemVersion
+        $osBuildName = if ($_.OperatingSystem -like "*Server*") {
+            $osVersionMapServer[$osVersion]
+        } else {
+            $osVersionMapWorkstation[$osVersion]
+        }
+
+        # Convert LastLogonTimestamp and LastSeen to DateTime
+        $lastLogonDateTime = [DateTime]::FromFileTime($_.lastLogonTimestamp)
+        $lastSeenDateTime = [DateTime]::FromFileTime($_.lastLogonTimestamp) # Adjust as needed for LastSeen logic
+
+        # Determine LastSeen string representation
+        $lastSeenString = switch ($lastSeenDateTime) {
+            { $_ -lt (Get-Date).Adddays(-90) } { '3+ months' }
+            { $_ -lt (Get-Date).Adddays(-60) } { '2+ months' }
+            { $_ -lt (Get-Date).Adddays(-30) } { '1+ month' }
+            default { 'Recently' }
+        }
+
+        # GroupMemberships processing (adjust as needed)
+        $groupMemberships = $(Get-ADGroupMemberof -SamAccountName $_.Name -AccountType ADComputer)
+
+        # Construct the ADAuditTasksComputer object
         [ADAuditTasksComputer]::new(
             $_.DNSHostName,
             $_.Name,
@@ -34,19 +93,21 @@ function Build-ADAuditTasksComputer {
             $_.IPv4Address,
             $_.IPv6Address,
             $_.OperatingSystem,
-            $_.lastLogonTimestamp,
-            $_.lastLogonTimestamp,
+            $lastLogonDateTime,
+            $lastSeenString, # Now passing the string representation
             $_.Created,
             $_.whenChanged,
             $_.Description,
             $_.DistinguishedName,
             (($_.KerberosEncryptionType | Out-String) -replace "`n" -replace "`r"),
             ($_.servicePrincipalName -join " | "),
-            $_.Name
+            $groupMemberships, # Now using processed group memberships
+            $osVersion, # New OperatingSystemVersion
+            $osBuildName # New OperatingSystemBuildName
         )
     } # End ForEach-Object
 
-    Write-AuditLog "The ADAUditTasksComputer objects were built successfully."
+    Write-AuditLog "The ADAuditTasksComputer objects were built successfully."
     Write-AuditLog -EndFunction
     return $Export
 }

--- a/source/Private/Initialize-ModuleEnv.ps1
+++ b/source/Private/Initialize-ModuleEnv.ps1
@@ -1,4 +1,3 @@
-function Initialize-ModuleEnv {
 <#
     .SYNOPSIS
     Initializes the environment by installing required PowerShell modules.
@@ -49,7 +48,8 @@ function Initialize-ModuleEnv {
     Author: DrIOSx
     This function makes extensive use of the Write-AuditLog function for logging actions, warnings, and errors. It also uses a script-scope variable $script:VerbosePreference for controlling verbose output.
 #>
-    [CmdletBinding(DefaultParameterSetName = "Public")]
+function Initialize-ModuleEnv {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact='Medium', DefaultParameterSetName = "Public")]
     param (
         [Parameter(ParameterSetName = "Public", Mandatory)]
         [string[]]$PublicModuleNames,
@@ -59,54 +59,40 @@ function Initialize-ModuleEnv {
         [string[]]$PrereleaseModuleNames,
         [Parameter(ParameterSetName = "Prerelease", Mandatory)]
         [string[]]$PrereleaseRequiredVersions,
-        [ValidateSet(
-            "AllUsers",
-            "CurrentUser"
-        )]
+        [ValidateSet("AllUsers", "CurrentUser")]
         [string]$Scope,
         [string[]]$ImportModuleNames = $null
     )
+
     # Start logging function execution
     if (!($script:LogString)) {
         Write-AuditLog -Start
-    }
-    else {
+    } else {
         Write-AuditLog -BeginFunction
     }
+
     # Function limit needs to be set higher if installing graph module and if powershell is version 5.1.
-    # The Microsoft.Graph module requires an increased function limit.
-    # If we're installing this module, set the function limit to 8192.
     if ($PublicModuleNames -match 'Microsoft.Graph' -or $PrereleaseModuleNames -match "Microsoft.Graph") {
         if ($script:MaximumFunctionCount -lt 8192) {
             $script:MaximumFunctionCount = 8192
         }
     }
-    # Check and install PowerShellGet.
-    # PowerShellGet is required for module management in PowerShell.
-    ### https://learn.microsoft.com/en-us/powershell/scripting/gallery/installing-psget?view=powershell-7.3
-    # Get all available versions of PowerShellGet
-    $PSGetVer = Get-Module -Name PowerShellGet -ListAvailable
 
-    # Initialize flag to false
+    # Check and install PowerShellGet
+    $PSGetVer = Get-Module -Name PowerShellGet -ListAvailable
     $notOneFlag = $false
 
-    # For each module version
     foreach ($module in $PSGetVer) {
-        # Check if version is different from "1.0.0.1"
         if ($module.Version -ne "1.0.0.1") {
             $notOneFlag = $true
             break
         }
     }
 
-    # If any version is different from "1.0.0.1", import the latest one
     if ($notOneFlag) {
-        # Sort by version in descending order and select the first one (the latest)
         $latestModule = $PSGetVer | Sort-Object Version -Descending | Select-Object -First 1
-        # Import the latest version
         Import-Module -Name $latestModule.Name -RequiredVersion $latestModule.Version
-    }
-    else {
+    } else {
         switch (Test-IsAdmin) {
             $false {
                 Write-AuditLog "PowerShellGet is version 1.0.0.1. Please run this once as an administrator, to update PowershellGet." -Severity Error
@@ -124,33 +110,33 @@ function Initialize-ModuleEnv {
             $PSGetVer = Get-Module -Name PowerShellGet -ListAvailable
             $latestModule = $PSGetVer | Sort-Object Version -Descending | Select-Object -First 1
             Import-Module -Name $latestModule.Name -RequiredVersion $latestModule.Version -ErrorAction Stop
-        }
-        catch {
+        } catch {
             throw $_.Exception
         }
     }
-    # End Region PowershellGet Install
+
     if ($Scope -eq "AllUsers") {
         switch (Test-IsAdmin) {
             $false {
-                Write-AuditLog "You must be an administrator to install in the `'AllUsers`' scope." -Severity Error
-                Write-AuditLog "If you intended to install the module only for this user, select the `'CurrentUser`' scope." -Severity Error
-                throw "Elevation required for `'AllUsers`' scope"
+                Write-AuditLog "You must be an administrator to install in the 'AllUsers' scope." -Severity Error
+                Write-AuditLog "If you intended to install the module only for this user, select the 'CurrentUser' scope." -Severity Error
+                throw "Elevation required for 'AllUsers' scope"
             }
             Default {
-                Write-AuditLog "You have sufficient privileges to install to the `'AllUsers`' scope."
+                Write-AuditLog "You have sufficient privileges to install to the 'AllUsers' scope."
             }
         }
     }
+
     if ($PSCmdlet.ParameterSetName -eq "Public") {
         $modules = $PublicModuleNames
         $versions = $PublicRequiredVersions
-    }
-    elseif ($PSCmdlet.ParameterSetName -eq "Prerelease") {
+    } elseif ($PSCmdlet.ParameterSetName -eq "Prerelease") {
         $modules = $PrereleaseModuleNames
         $versions = $PrereleaseRequiredVersions
         $prerelease = $true
     }
+
     foreach ($module in $modules) {
         $name = $module
         $version = $versions[$modules.IndexOf($module)]
@@ -158,14 +144,14 @@ function Initialize-ModuleEnv {
         switch (($null -eq $ImportModuleNames)) {
             $false {
                 $SelectiveImports = $ImportModuleNames | Where-Object { $_ -match $name }
-                Write-AuditLog "Attempting to selecively install module/s:"
+                Write-AuditLog "Attempting to selectively install module/s:"
             }
             Default {
                 $SelectiveImports = $null
                 Write-AuditLog "Selective imports were not specified. All functions and commands will be imported."
             }
         }
-        # Get Module Object
+
         switch ($prerelease) {
             $true {
                 $message = "The PreRelease module $name version $version is not installed. Would you like to install it?"
@@ -176,65 +162,64 @@ function Initialize-ModuleEnv {
                 $throwmsg = "You must install the $name module version $version to continue."
             }
         }
+
         if (!$installedModule) {
-            # Install Required Module
-            Write-AuditLog $message -Severity Warning
-            try {
-                Write-AuditLog "Installing $name module/s version $version -AllowPrerelease:$prerelease."
-                $SaveVerbosePreference = $script:VerbosePreference
-                Install-Module $name -Scope $Scope -RequiredVersion $version -AllowPrerelease:$prerelease -ErrorAction Stop -Verbose:$false
-                $script:VerbosePreference = $SaveVerbosePreference
-                Write-AuditLog "$name module successfully installed!"
-                if ($SelectiveImports) {
-                    foreach ($Mod in $SelectiveImports) {
-                        $name = $Mod
-                        Write-AuditLog "Selectively importing the $name module."
+            if ($PSCmdlet.ShouldProcess("$name module version $version", "Install")) {
+                Write-AuditLog $message -Severity Warning
+                try {
+                    Write-AuditLog "Installing $name module/s version $version -AllowPrerelease:$prerelease."
+                    $SaveVerbosePreference = $script:VerbosePreference
+                    Install-Module $name -Scope $Scope -RequiredVersion $version -AllowPrerelease:$prerelease -ErrorAction Stop -Verbose:$false
+                    $script:VerbosePreference = $SaveVerbosePreference
+                    Write-AuditLog "$name module successfully installed!"
+                    if ($SelectiveImports) {
+                        foreach ($Mod in $SelectiveImports) {
+                            $name = $Mod
+                            Write-AuditLog "Selectively importing the $name module."
+                            $SaveVerbosePreference = $script:VerbosePreference
+                            Import-Module $name -ErrorAction Stop -Verbose:$false
+                            $script:VerbosePreference = $SaveVerbosePreference
+                            Write-AuditLog "Successfully imported the $name module."
+                        }
+                    } else {
+                        Write-AuditLog "Importing the $name module."
                         $SaveVerbosePreference = $script:VerbosePreference
                         Import-Module $name -ErrorAction Stop -Verbose:$false
                         $script:VerbosePreference = $SaveVerbosePreference
                         Write-AuditLog "Successfully imported the $name module."
                     }
-                }
-                else {
-                    Write-AuditLog "Importing the $name module."
-                    $SaveVerbosePreference = $script:VerbosePreference
-                    Import-Module $name -ErrorAction Stop -Verbose:$false
-                    $script:VerbosePreference = $SaveVerbosePreference
-                    Write-AuditLog "Successfully imported the $name module."
+                } catch {
+                    Write-AuditLog $throwmsg -Severity Error
+                    throw $_.Exception
                 }
             }
-            catch {
-                Write-AuditLog $throwmsg -Severity Error
-                throw $_.Exception
-            }
-        }
-        else {
-            try {
-                if ($SelectiveImports) {
-                    foreach ($Mod in $SelectiveImports) {
-                        $name = $Mod
+        } else {
+            if ($PSCmdlet.ShouldProcess("$name module", "Import")) {
+                try {
+                    if ($SelectiveImports) {
+                        foreach ($Mod in $SelectiveImports) {
+                            $name = $Mod
+                            Write-AuditLog "The $name module was found to be installed."
+                            Write-AuditLog "Selectively importing the $name module."
+                            $SaveVerbosePreference = $script:VerbosePreference
+                            Import-Module $name -ErrorAction Stop -Verbose:$false
+                            $script:VerbosePreference = $SaveVerbosePreference
+                            Write-AuditLog "Successfully imported the $name module."
+                            Write-AuditLog -EndFunction
+                        }
+                    } else {
                         Write-AuditLog "The $name module was found to be installed."
-                        Write-AuditLog "Selectively importing the $name module."
+                        Write-AuditLog "Importing the $name module."
                         $SaveVerbosePreference = $script:VerbosePreference
                         Import-Module $name -ErrorAction Stop -Verbose:$false
                         $script:VerbosePreference = $SaveVerbosePreference
                         Write-AuditLog "Successfully imported the $name module."
                         Write-AuditLog -EndFunction
                     }
+                } catch {
+                    Write-AuditLog $throwmsg -Severity Error
+                    throw $_.Exception
                 }
-                else {
-                    Write-AuditLog "The $name module was found to be installed."
-                    Write-AuditLog "Importing the $name module."
-                    $SaveVerbosePreference = $script:VerbosePreference
-                    Import-Module $name -ErrorAction Stop -Verbose:$false
-                    $script:VerbosePreference = $SaveVerbosePreference
-                    Write-AuditLog "Successfully imported the $name module."
-                    write-auditlog -EndFunction
-                }
-            }
-            catch {
-                Write-AuditLog $throwmsg -Severity Error
-                throw $_.Exception
             }
         }
     }

--- a/source/Public/Get-ADHostAudit.ps1
+++ b/source/Public/Get-ADHostAudit.ps1
@@ -141,9 +141,11 @@ https://criticalsolutionsnetwork.github.io/ADAuditTasks/#Get-ADHostAudit
         "lastLogonTimestamp",
         "Name",
         "OperatingSystem",
+        "OperatingSystemVersion", # Newly added property
         "DistinguishedName",
         "servicePrincipalName",
         "whenChanged"
+
 
     } # End Begin
     process {
@@ -155,7 +157,7 @@ https://criticalsolutionsnetwork.github.io/ADAuditTasks/#Get-ADHostAudit
         if ($OSPicked) {
             Write-AuditLog "And Operating System is like: $OSPicked."
             Get-ADComputer -Filter { (LastLogonTimeStamp -gt $time) -and (Enabled -eq $Enabled) -and (OperatingSystem -like $OSPicked) }`
-            -Properties $propsArray -OutVariable ADComps | Out-Null
+                -Properties $propsArray -OutVariable ADComps | Out-Null
         }
         elseif ($POSIX) {
             Write-AuditLog "And Operating System is: Non-Windows(POSIX)."

--- a/source/Public/Get-ADHostAudit.ps1
+++ b/source/Public/Get-ADHostAudit.ps1
@@ -1,38 +1,38 @@
 function Get-ADHostAudit {
-    <#
-.SYNOPSIS
-    Active Directory Server and Workstation Audit with Report export option (Can also be piped to CSV if Report isn't specified).
-.DESCRIPTION
-    Audits Active Directory for hosts that haven't signed in for a specified number of days. Output can be piped to a CSV manually, or automatically saved to C:\temp\ADHostAudit or a specified directory using the -Report switch.
+<#
+    .SYNOPSIS
+        Active Directory Server and Workstation Audit with Report export option (Can also be piped to CSV if Report isn't specified).
+    .DESCRIPTION
+        Audits Active Directory for hosts that haven't signed in for a specified number of days. Output can be piped to a CSV manually, or automatically saved to C:\temp\ADHostAudit or a specified directory using the -Report switch.
 
-    Use the Tab key to cycle through the -HostType parameter.
-.EXAMPLE
-    PS C:\> Get-ADHostAudit -HostType WindowsServers -Report -Verbose
-.EXAMPLE
-    PS C:\> Get-ADHostAudit -HostType WindowsWorkstations -Report -Verbose
-.EXAMPLE
-    PS C:\> Get-ADHostAudit -HostType "Non-Windows" -Report -Verbose
-.EXAMPLE
-    PS C:\> Get-ADHostAudit -OSType "2008" -DirPath "C:\Temp\" -Report -Verbose
-.PARAMETER HostType
-    Specifies the type of hosts to search for. Valid values are WindowsServers, WindowsWorkstations, and Non-Windows.
-.PARAMETER OSType
-    Specifies the operating system to search for. There is no need to add wildcards.
-.PARAMETER DaystoConsiderAHostInactive
-    Specifies the number of days to consider a host as inactive.
-.PARAMETER Report
-    Saves a CSV report to the specified directory.
-.PARAMETER AttachmentFolderPath
-    Specifies the directory where attachments will be saved.
-.PARAMETER Enabled
-    If set to $false, the function will also search for disabled computers.
-.NOTES
-    By default, output is saved to C:\temp\ADHostAudit.
-    For more information, type: Get-Help Get-ADHostAudit -ShowWindow
-.LINK
-https://github.com/CriticalSolutionsNetwork/ADAuditTasks/wiki/Get-ADHostAudit
-.LINK
-https://criticalsolutionsnetwork.github.io/ADAuditTasks/#Get-ADHostAudit
+        Use the Tab key to cycle through the -HostType parameter.
+    .EXAMPLE
+        PS C:\> Get-ADHostAudit -HostType WindowsServers -Report -Verbose
+    .EXAMPLE
+        PS C:\> Get-ADHostAudit -HostType WindowsWorkstations -Report -Verbose
+    .EXAMPLE
+        PS C:\> Get-ADHostAudit -HostType "Non-Windows" -Report -Verbose
+    .EXAMPLE
+        PS C:\> Get-ADHostAudit -OSType "2008" -DirPath "C:\Temp\" -Report -Verbose
+    .PARAMETER HostType
+        Specifies the type of hosts to search for. Valid values are WindowsServers, WindowsWorkstations, and Non-Windows.
+    .PARAMETER OSType
+        Specifies the operating system to search for. There is no need to add wildcards.
+    .PARAMETER DaystoConsiderAHostInactive
+        Specifies the number of days to consider a host as inactive.
+    .PARAMETER Report
+        Saves a CSV report to the specified directory.
+    .PARAMETER AttachmentFolderPath
+        Specifies the directory where attachments will be saved.
+    .PARAMETER Enabled
+        If set to $false, the function will also search for disabled computers.
+    .NOTES
+        By default, output is saved to C:\temp\ADHostAudit.
+        For more information, type: Get-Help Get-ADHostAudit -ShowWindow
+    .LINK
+    https://github.com/CriticalSolutionsNetwork/ADAuditTasks/wiki/Get-ADHostAudit
+    .LINK
+    https://criticalsolutionsnetwork.github.io/ADAuditTasks/#Get-ADHostAudit
 #>
 
 
@@ -145,7 +145,6 @@ https://criticalsolutionsnetwork.github.io/ADAuditTasks/#Get-ADHostAudit
         "DistinguishedName",
         "servicePrincipalName",
         "whenChanged"
-
 
     } # End Begin
     process {


### PR DESCRIPTION
# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Prepend the title with the [DscResourceName] if your PR is specific to a DSC resource.
    Also prepend with [BREAKING CHANGE] if relevant.
    i.e. [BREAKING CHANGE][xFile] Add security descriptor property

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
-->

## Pull Request (PR) description

<!--
    Replace this comment block with a description of your PR to provide context.
    Please be describe the intent and link issue where the problem has been discussed.
    try to link the issue that it fixes by providing the verb and ref: [fix|close #18]

    After the description, please concisely list the changes as per keepachangelog.com
    This **should** duplicate what you've updated in the changelog file.

### Added
- for new features [closes #15]
### Changed
- for changes in existing functionality.
### Deprecated
- for soon-to-be removed features.
### Security
- in case of vulnerabilities.
### Fixed
- for any bug fixes. [fix #52]
### Removed
- for now removed features.
-->

### Added

- Added `OperatingSystemVersion` and `OperatingSystemBuildName` properties to `ADAuditTasksComputer` class.
- Updated `Build-ADAuditTasksComputer` function to include logic for mapping OS versions to human-readable names using new hash tables `$osVersionMapWorkstation` and `$osVersionMapServer`.
- Modified `Get-ADHostAudit` function to include `OperatingSystemVersion` in `$propsArray`, ensuring compatibility with changes in `ADAuditTasksComputer` class.

### Changed

- Refactored `ADAuditTasksComputer` class to improve clarity and maintainability, moving data transformation logic to `Build-ADAuditTasksComputer` function.
- Adjusted `Build-ADAuditTasksComputer` function to align with the refactored `ADAuditTasksComputer` class, preserving original functionality and output format.

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
